### PR TITLE
Feature: additional info tabs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 const prettify = require('html-prettify');
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+const md = require('markdown-it')({ html: true });
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(syntaxHighlight);
@@ -12,6 +13,10 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addFilter('console', function(value) {
     return JSON.stringify(value, null, 2);
+  });
+
+  eleventyConfig.addPairedShortcode('markdown', (content) => {
+    return md.render(content);
   });
 
   eleventyConfig.addPairedShortcode('brace', function(content, type = 'curly') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
+    "node_modules/@11ty/dependency-tree": {
   "dependencies": {
     "@11ty/dependency-tree": {
       "version": "2.0.1",

--- a/src/_data/components.js
+++ b/src/_data/components.js
@@ -1,5 +1,6 @@
 const slugify = require('slugify');
 const requireGlob = require('require-glob');
+const path = require('path');
 
 function convertComponent(component) {
   // Extract variants from component and remove them
@@ -46,10 +47,10 @@ function convertComponent(component) {
 function reducer(options, tree, fileObj) {
   if (!fileObj) return tree;
   if (tree.components === undefined) tree.components = [];
-  const path = fileObj.path.split('/');
+  let componentPath = path.parse(fileObj.path);
   tree.components.push({
     ...fileObj.exports,
-    name: path[path.length - 2]
+    name: componentPath.name.split('.')[0]
   });
   return tree;
 }

--- a/src/_includes/components/button/button.md
+++ b/src/_includes/components/button/button.md
@@ -1,0 +1,3 @@
+## Button component
+
+Here is some additional informaiton on how to use the button component and its variants. 

--- a/src/_includes/components/button/button.md
+++ b/src/_includes/components/button/button.md
@@ -1,3 +1,3 @@
 ## Button component
 
-Here is some additional informaiton on how to use the button component and its variants. 
+Here is a place to putt  some additional information on how to use the button component and its variants. 

--- a/src/_includes/design-system/component.njk
+++ b/src/_includes/design-system/component.njk
@@ -2,6 +2,12 @@
   {% include "../components/" + name + "/" + name + ".njk" ignore missing %}
 {%- endmacro -%}
 
+{% macro notes(name, params) %}
+  {% markdown %}
+  {% include "../components/" + name + "/" + name + ".md" ignore missing %}
+  {% endmarkdown %}
+{% endmacro %}
+
 {% macro code(name, params) %}
   {% highlight "html" %}
     {%- prettify -%}

--- a/src/components-pages.njk
+++ b/src/components-pages.njk
@@ -12,14 +12,16 @@ renderData:
 
 {% extends "./_includes/design-system/library.njk" %}
 
-{% from "design-system/component.njk" import code, context %}
+{% from "design-system/component.njk" import code, notes, context %}
 
 {% block content %}
   <seven-minute-tabs class="ds-stretch">
     <ol role="tablist" class="ds-tabs" aria-label="What does this tab chooser do?">
       <li><a class="ds-link" href="#example-tab" role="tab">Demo</a></li>
-      <li><a class="ds-link" href="#code-tab" role="tab">.html</a></li>
-      <li><a class="ds-link" href="#context-tab" role="tab">.njk & context</a></li>
+      <li><a class="ds-link" href="#notes-tab" role="tab">Notes</a></li>
+      <li><a class="ds-link" href="#code-tab" role="tab">HTML</a></li>
+      <li><a class="ds-link" href="#context-tab" role="tab">NJK with context</a></li>
+      <li><a class="ds-link" href="#info-tab" role="tab">Info</a></li>
       <li><a class="ds-link" href="/components/full/{{ component.slug }}">Full Screen ↗</a></li>
     </ol>
 
@@ -29,6 +31,10 @@ renderData:
       </div>
     </div>
 
+    <div id="notes-tab" role="tabpanel" class="ds-stretch">
+      {{ notes(component.name, component.context) }}
+    </div>
+
     <div id="code-tab" role="tabpanel" class="ds-code ds-stretch">
       {{ code(component.name, component.context) }}
     </div>
@@ -36,5 +42,10 @@ renderData:
     <div id="context-tab" role="tabpanel" class="ds-code ds-stretch">
       {{ context(component.name, component.context) }}
     </div>
+
+    <div id="info-tab" role="tabpanel" class="ds-code ds-stretch">
+      <pre>{{ component | dump(2) }}</pre>
+    </div>
+
   </seven-minute-tabs>
 {% endblock %}


### PR DESCRIPTION
This adds some possibly nice features:

- a `{% markdown %}` shortcode powered by the existing `markdown-it` dependency
- a "Notes" tab that consume `componentName.md` file  -- for guidance on how to use a component
- an "Info" tab with various diagnostic information that is sometimes helpful

I fully realise these are in the spectrum of "possibly wanted" so I'll take no offense if you simply close the PR.

Screengrabs:

![grafik](https://user-images.githubusercontent.com/928100/180795389-1b7908b1-4464-41d7-bc9e-2de1384e36d5.png)

![grafik](https://user-images.githubusercontent.com/928100/180795437-7e7d5983-6c72-4389-8a79-3e8bbaae6744.png)
